### PR TITLE
fix(release): defer update metadata until publish

### DIFF
--- a/pages/version.json
+++ b/pages/version.json
@@ -1,6 +1,6 @@
 {
-  "latestVersion": "2.2.1",
-  "build_number": 9,
+  "latestVersion": "2.1.2",
+  "build_number": 5,
   "releaseURL": "https://github.com/kmgcc/kmgccc_player/releases/latest",
-  "notes": "新增本地播放历史、下一首播放和按皮肤保存的全屏歌词字体设置\n窗口 MiniPlayer 支持音频可视化，并在不可见时暂停采样以降低占用\n新增异常退出报告保存与发送流程\n改进全景、画框等皮肤的过渡、色彩和频谱表现\n修复退出延迟、频谱无信号、多选状态丢失和无封面异常等问题"
+  "notes": "全新 Home 页面，可浏览专辑、艺人与播放列表\n资料库支持自定义位置，管理更完善\n点小窗口支持全屏沉浸播放，支持调整显示效果\nLED 模拟焕新，新增呼吸灯效果\n新增播放记忆，启动 App 可恢复上次状态\n……\n更多新功能详见 release 页面"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,6 +88,12 @@ Xcode 的 `Run Optional Build Hook` Build Phase 调用此适配器。默认设�
 
 最终 App 中受控路径下的加密素材容器和编译后 Metal library 属于可分发运行产物；源码、明文素材、脚本，以及这些运行产物出现在公开工作树或 Git 历史中仍会阻断发布。它们不属于 `verify.sh` 的 PR 门禁。
 
+公开发布按以下顺序收口：
+
+1. 用已合并且通过 CI 的精确提交构建、审计并准备 Draft Release；Draft 只包含 DMG、`.symbols.zip` 和 `.sha256`。
+2. 复核 Draft 的目标提交、资产 digest、签名说明和安装说明后，先发布 GitHub Release。
+3. Release 已公开且 `/releases/latest` 指向新版本后，再通过独立 PR 更新 `pages/version.json`。不要让在线更新元数据提前指向仍处于 Draft 的版本。
+
 ## 约定
 
 - 脚本从仓库根目录运行，并自行解析仓库路径。


### PR DESCRIPTION
## Summary

- keep the live update feed on the currently published 2.1.2 release while 2.2.1 remains a draft
- document that GitHub Release publication must precede the Pages update metadata switch

## Why

Publishing update metadata before the release is public sends users to the previous /releases/latest target. The 2.2.1 Draft and its audited assets are unchanged.

## Validation

- textual hygiene passed
- selected-history release audit passed
- JSON content restored to the currently public release values