### PR TITLE
release: publish 2.2.1 update metadata

### DIFF
--- a/pages/version.json
+++ b/pages/version.json
@@ -1,6 +1,6 @@
 {
-  "latestVersion": "2.1.2",
-  "build_number": 5,
+  "latestVersion": "2.2.1",
+  "build_number": 9,
   "releaseURL": "https://github.com/kmgcc/kmgccc_player/releases/latest",
-  "notes": "全新 Home 页面，可浏览专辑、艺人与播放列表\n资料库支持自定义位置，管理更完善\n点小窗口支持全屏沉浸播放，支持调整显示效果\nLED 模拟焕新，新增呼吸灯效果\n新增播放记忆，启动 App 可恢复上次状态\n……\n更多新功能详见 release 页面"
+  "notes": "新增本地播放历史、下一首播放和按皮肤保存的全屏歌词字体设置\n窗口 MiniPlayer 支持音频可视化，并在不可见时暂停采样以降低占用\n新增异常退出报告保存与发送流程\n改进全景、画框等皮肤的过渡、色彩和频谱表现\n修复退出延迟、频谱无信号、多选状态丢失和无封面异常等问题"
 }


### PR DESCRIPTION
## Summary
- publish 2.2.1 build 9 in the Pages update feed
- refresh the user-facing update notes
- keep the update URL on the public latest-release endpoint

## Release verification
- tag `9` is public and `/releases/latest` resolves to it
- release target is `bbb82bec9c13d1f6e46b834d02af2b1e931fe143`
- DMG, symbols, and checksum asset digests match the prepared release

## Validation
- `jq empty pages/version.json`
- `git diff --check`
- `./scripts/verify_textual_hygiene.sh`
- `./scripts/audit_release_contents.sh --ref HEAD`